### PR TITLE
Adding support for executing scripts before the restic backup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ After installation the backup process can be tested following this procedure:
 
 1) Trigger manually the backup process
 
-       systemctl start restic-backu
+       systemctl start restic-backup
     
    Or
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ Available variables are listed below along with default values (see `defaults\ma
       restic_ca_cert: "{{ lookup('file','certificates/CA.pem') }}"
   ```
 
+- Pre-backup scripts
+
+  In the scheduled backup, scripts can be executed just before restic backup commands. This is useful to schedule manual task like generating the backup files of database (i.e.: mysqldump command).
+
+  `restic_enable_pre_backup_scripts` enable the execution of those scripts
+  `restic_pre_backup_script` contains the list of scripts (name + content) to be executed
+  
+  This is an example of script to be executed before applying restic backup commands
+  ```yml
+  restic_enable_pre_backup_scripts: false
+  restic_pre_backup_script:
+    - name: myprebackup.sh
+      content: |
+        #!/bin/bash
+        echo "This is a script executed before making the backup"
+  ```
 - Directories list to be backed up
 
   `restic_backup_dirs` is a list of dictionaries. Each item of the list is a directory to  include in the backup

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ restic_path: /usr/local/bin/restic
 restic_etc_dir: /etc/restic
 # restic CA dir (--caCert option)
 restic_ca_dir: "{{ restic_etc_dir }}/ssl"
+# restic pre-backup scripts dir
+restic_etc_scripts_dir: "{{ restic_etc_dir }}/scripts"
 
 # restic service env file
 restic_service_envfile: "{{ restic_etc_dir }}/restic.conf"
@@ -57,6 +59,15 @@ restic_backups_dirs:
     exclude:
       - pattern: '.cache'
       - pattern: '.ignore'
+
+# restic pre-backup scripts
+restic_enable_pre_backup_scripts: false
+restic_pre_backup_script: []
+#  - name: myprebackup.sh
+#    content: |
+#       #!/bin/bash
+#       echo "This is a script executed before making the backup"
+
 
 # Restic command additional flags
 restic_flags: ""

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,3 +20,9 @@
       restic_repository: "/restic-repo"
       restic_password: supers1cret0
       gclone_install: false
+      restic_enable_pre_backup_scripts: true
+      restic_pre_backup_script:
+        - name: myprebackup.sh
+          content: |
+              #!/bin/bash
+              echo "This is a script executed before making the backup"

--- a/tasks/configure_restic.yml
+++ b/tasks/configure_restic.yml
@@ -9,6 +9,7 @@
     mode: 0750
   with_items:
     - "{{ restic_etc_dir }}"
+    - "{{ restic_etc_scripts_dir }}"
     - "{{ restic_ca_dir }}"
 
 - name: Copy custom CA cert
@@ -53,6 +54,15 @@
       dest: "{{ restic_etc_dir }}/restic-repo-clean.sh"
     - template: restic-wrapper.sh.j2
       dest: "{{ restic_etc_dir }}/restic-wrapper.sh"
+
+- name: Copy Pre-backup scripts
+  include_tasks:
+    file: copy_pre_backup_script.yml
+  loop: "{{ restic_pre_backup_script }}"
+  loop_control:
+    loop_var: prebackup_script
+  when:
+    - restic_pre_backup_script is defined
 
 - name: Initialize restic repo
   command:

--- a/tasks/copy_pre_backup_script.yml
+++ b/tasks/copy_pre_backup_script.yml
@@ -1,0 +1,12 @@
+---
+- name: test prebackup_script
+  ansible.builtin.assert:
+    that:
+      - prebackup_script.name is defined
+    quiet: true
+
+- name: copy prebackup script
+  copy:
+    dest: "{{ restic_etc_scripts_dir }}/{{ prebackup_script.name }}"
+    content: "{{ prebackup_script.content }}"
+    mode: 0755

--- a/templates/restic-backup.sh.j2
+++ b/templates/restic-backup.sh.j2
@@ -7,13 +7,27 @@ date "+%b %d %Y %T %Z"
 
 RESTIC_WRAPPER={{ restic_etc_dir }}/restic-wrapper.sh
 LOG={{ restic_log }}
+RESTIC_PREBACKUP_SCRIPTS_DIR={{ restic_etc_dir }}/scripts
 
+{% if restic_enable_pre_backup_scripts %}
+# Add timestamp
+echo "$(timestamp): pre-backup scripts execution started" | tee -a $LOG
+echo "-------------------------------------------------------------------------------" | tee -a $LOG
+
+{% for script in restic_pre_backup_script %}
+{% if script.name is defined %}
+echo "$(timestamp): Script {{ script.name }} execution started" | tee -a $LOG
+RESTIC_PREBACKUP_SCRIPTS_DIR/{{ script.name }}
+{% endif %}
+{% endfor %}
+{% endif %}
 # Add timestamp
 echo "$(timestamp): restic-backup started" | tee -a $LOG
 echo "-------------------------------------------------------------------------------" | tee -a $LOG
 
 # Run Backups
 {% for dir in restic_backups_dirs %}
+echo "$(timestamp):  Dir {{ dir.path }} backup started" | tee -a $LOG
 $RESTIC_WRAPPER backup {{ dir.path }} \
 {% if dir.exclude is defined %}
 {% for exclude in dir.exclude %}

--- a/templates/restic-backup.sh.j2
+++ b/templates/restic-backup.sh.j2
@@ -6,8 +6,6 @@ date "+%b %d %Y %T %Z"
 }
 
 RESTIC_WRAPPER={{ restic_etc_dir }}/restic-wrapper.sh
-EXCLUDE={{ restic_exclude_file }}
-INCLUDE={{ restic_include_file }}
 LOG={{ restic_log }}
 
 # Add timestamp

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,10 +8,6 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
-restic_exclude_file: "{{ restic_etc_dir }}/restic-exclude.txt"
-
-restic_include_file: "{{ restic_etc_dir }}/restic-include.txt"
-
 rclone_package_list:
   - unzip
   - curl


### PR DESCRIPTION
Restic backup script, scheduled with systemd timer,  is updated to execute additional scripts before launching `restic backup` commands. Those additional scripts are automatically uploaded by the role.